### PR TITLE
Add Github Action to Validate the WorkbooksMetadata json schema

### DIFF
--- a/.github/workflows/metadata_schema.json
+++ b/.github/workflows/metadata_schema.json
@@ -1,0 +1,78 @@
+{
+    "type": "array",
+    "items": [
+        {
+            "type": "object",
+            "properties": {
+                "workbookKey": {
+                    "type": "string"
+                },
+                "logoFileName": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "dataTypesDependencies": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "dataConnectorsDependencies": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "previewImagesFileNames": {
+                    "type": "array",
+                    "items": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "string"
+                        }
+                    ]
+                },
+                "version": {
+                    "type": "string"
+                },
+                "title": {
+                    "type": "string"
+                },
+                "templateRelativePath": {
+                    "type": "string"
+                },
+                "subtitle": {
+                    "type": "string"
+                },
+                "provider": {
+                    "type": "string"
+                },
+                "featureFlag": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "workbookKey",
+                "logoFileName",
+                "description",
+                "dataTypesDependencies",
+                "dataConnectorsDependencies",
+                "previewImagesFileNames",
+                "version",
+                "title",
+                "templateRelativePath",
+                "subtitle",
+                "provider"
+            ],
+            "additionalProperties": false
+        }
+    ]
+}

--- a/.github/workflows/validate_workbooks.yml
+++ b/.github/workflows/validate_workbooks.yml
@@ -1,0 +1,19 @@
+name: Validate WorkbooksMetadata
+
+on: 
+  pull_request:
+    paths:
+    - 'Workbooks/WorkbooksMetadata.json'
+
+jobs:
+  validate-workbooks-metadata:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+    - name: Validate WorkbooksMetadata.json
+      uses: docker://orrosenblatt/validate-json-action:latest
+      env:
+        INPUT_SCHEMA: ./.github/workflows/metadata_schema.json
+        INPUT_JSONS: ./Workbooks/WorkbooksMetadata.json


### PR DESCRIPTION
## Proposed Changes
Apply a new github action that triggers upon PR submission which contains changes to the WorkbooksMetadata file

The validation will reflect whether or not the schema is valid, i.e. 
- it does not contain illegal properties 
- is has the proper data type

The  `metadata_schma.json` is the schema that the action will use to verify the json file.